### PR TITLE
Add Error Bar and Prevent Guessing During Voting Phase

### DIFF
--- a/app/components/ErrorBar.tsx
+++ b/app/components/ErrorBar.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface ErrorBarProps {
+  message: string;
+  duration?: number;
+  onDone?: () => void;
+}
+
+export const ErrorBar = (
+  { message, duration = 3000, onDone }: ErrorBarProps,
+) => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(true);
+    const timer = setTimeout(() => {
+      setVisible(false);
+      setTimeout(() => {
+        onDone?.();
+      }, 400);
+    }, duration);
+
+    return () => clearTimeout(timer);
+  }, [duration, onDone]);
+
+  return createPortal(
+    <div
+      className={`error-bar ${visible ? "fade-in" : "fade-out"}`}
+      role="alert"
+    >
+      <i className="bi bi-exclamation-triangle-fill me-2"></i>
+      {message}
+    </div>,
+    document.body,
+  );
+};

--- a/app/components/gallery.tsx
+++ b/app/components/gallery.tsx
@@ -9,6 +9,7 @@ import { HighlightedImage } from "@/types/highlightedImage";
 import { Button } from "./Button";
 import { useGame } from "@/hooks/useGame";
 import { GamePhase } from "@/types/gamePhase";
+import { useErrorBar } from "@/context/ErrorBarContext";
 
 type Props = {
   role: Role;
@@ -21,6 +22,7 @@ export const Gallery = (
 ) => {
   const apiService = useApi();
   const gameApi = useGame();
+  const { showError } = useErrorBar();
   const [imageList, setImageList] = useState<(string | null)[]>(
     Array(9).fill(null),
   );
@@ -102,7 +104,11 @@ export const Gallery = (
                     >
                       <Button
                         onClick={() => {
-                          gameApi.sendGuess(index);
+                          if (phase == GamePhase.GAME) {
+                            gameApi.sendGuess(index);
+                          } else {
+                            showError("Cannot guess during voting!", 2000);
+                          }
                         }}
                       >
                         Guess

--- a/app/components/gallery.tsx
+++ b/app/components/gallery.tsx
@@ -8,14 +8,16 @@ import { Role } from "@/types/role";
 import { HighlightedImage } from "@/types/highlightedImage";
 import { Button } from "./Button";
 import { useGame } from "@/hooks/useGame";
+import { GamePhase } from "@/types/gamePhase";
 
 type Props = {
   role: Role;
   highlightedImage: HighlightedImage;
+  phase: GamePhase;
 };
 
 export const Gallery = (
-  { role, highlightedImage }: Props,
+  { role, highlightedImage, phase }: Props,
 ) => {
   const apiService = useApi();
   const gameApi = useGame();

--- a/app/context/ErrorBarContext.tsx
+++ b/app/context/ErrorBarContext.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
+import { ErrorBar } from "@/components/ErrorBar";
+
+interface ErrorBarContextValue {
+  showError: (message: string, duration?: number) => void;
+}
+
+const ErrorBarContext = createContext<ErrorBarContextValue | undefined>(
+  undefined,
+);
+
+export const useErrorBar = (): ErrorBarContextValue => {
+  const context = useContext(ErrorBarContext);
+  if (!context) {
+    throw new Error("useErrorBar must be used within an ErrorBarProvider");
+  }
+  return context;
+};
+
+export const ErrorBarProvider = ({ children }: { children: ReactNode }) => {
+  const [message, setMessage] = useState<string | null>(null);
+  const [duration, setDuration] = useState<number>(3000);
+
+  const showError = useCallback((msg: string, dur?: number) => {
+    setMessage(msg);
+    setDuration(dur ?? 3000);
+  }, []);
+
+  return (
+    <ErrorBarContext.Provider value={{ showError }}>
+      {children}
+      {message && (
+        <ErrorBar
+          key={message + duration}
+          message={message}
+          duration={duration}
+          onDone={() => setMessage(null)}
+        />
+      )}
+    </ErrorBarContext.Provider>
+  );
+};

--- a/app/game/[code]/lobby.tsx
+++ b/app/game/[code]/lobby.tsx
@@ -8,15 +8,12 @@ import { SummaryCard } from "@/components/SummaryCard";
 import { GamePhase } from "@/types/gamePhase";
 import { useTheme } from "@/context/ThemeContext";
 
-
 type Props = {
   phase: GamePhase;
 };
 
 export default function LobbyPage({ phase }: Props) {
   const { toggleTheme } = useTheme();
-
-  
 
   return (
     <div>

--- a/app/game/[code]/page.tsx
+++ b/app/game/[code]/page.tsx
@@ -89,5 +89,7 @@ export default function GamePage() {
   if (role === null || highlightedImage === null) {
     return <div>Waiting for role...</div>;
   }
-  return <PlayPage role={role} highlightedImage={highlightedImage} />;
+  return (
+    <PlayPage role={role} highlightedImage={highlightedImage} phase={phase} />
+  );
 }

--- a/app/game/[code]/play.tsx
+++ b/app/game/[code]/play.tsx
@@ -5,15 +5,17 @@ import { HUD } from "@/components/hud";
 import { PlayerOverview } from "@/components/PlayerOverview";
 import { VerticalFlex } from "@/components/verticalFlex";
 import { Voting } from "@/components/voting";
+import { GamePhase } from "@/types/gamePhase";
 import { HighlightedImage } from "@/types/highlightedImage";
 import { Role } from "@/types/role";
 
 type Props = {
   role: Role;
   highlightedImage: HighlightedImage;
+  phase: GamePhase;
 };
 
-export default function PlayPage({ role, highlightedImage }: Props) {
+export default function PlayPage({ role, highlightedImage, phase }: Props) {
   return (
     <div className="play-page">
       <VerticalFlex width={350}>
@@ -26,6 +28,7 @@ export default function PlayPage({ role, highlightedImage }: Props) {
         <Gallery
           role={role}
           highlightedImage={highlightedImage}
+          phase={phase}
         />
       </VerticalFlex>
     </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,8 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import "bootstrap-icons/font/bootstrap-icons.css";
 import "@/styles/style.css";
 import "@/styles/layout.css";
-import { ThemeProvider } from "@/context/ThemeContext"; 
+import { ThemeProvider } from "@/context/ThemeContext";
+import { ErrorBarProvider } from "./context/ErrorBarContext";
 
 export const metadata: Metadata = {
   title: "SpyQuest",
@@ -18,7 +19,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-      <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          <ErrorBarProvider>
+            {children}
+          </ErrorBarProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/styles/layout.css
+++ b/app/styles/layout.css
@@ -483,6 +483,18 @@ main,
   word-break: break-word;
 }
 
+/* === ERROR-BAR === */
+.error-bar {
+  position: fixed;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.5rem 2rem;
+  display: flex;
+  align-items: center;
+  z-index: 9999;
+}
+
 /* === RESPONSIVE DESIGN === */
 
 @media (max-width: 1024px) {

--- a/app/styles/style.css
+++ b/app/styles/style.css
@@ -212,3 +212,25 @@ body.dark {
   visibility: hidden !important;
   transition-delay: 0s !important;
 }
+
+/* === ERROR-BAR === */
+.error-bar {
+  background-color: var(--user-color-1);
+  color: var(--background-light);
+  border-radius: 0 0 0.66rem 0.66rem;
+  font-weight: 600;
+  opacity: 0;
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  pointer-events: none;
+}
+
+.fade-in {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+  pointer-events: auto;
+}
+
+.fade-out {
+  opacity: 0;
+  transform: translateX(-50%) translateY(-10px);
+}


### PR DESCRIPTION
Adds a reusable error bar through context. Uses such an error bar to display an error when the spy tries to guess an image while a voting phase is taking place.